### PR TITLE
Crash when dropping from notebook outside the application window

### DIFF
--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -74,6 +74,11 @@ END_EVENT_TABLE()
 // -- wxAuiNotebook class implementation --
 bool wxAuiNotebook::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style)
 {
+    //Necessary for backwards compatibility with old wxAuiNotebook control - if we don't strip these flags then we end up with an ugly border around notebooks (where there was none before) in old code.
+    style &= ~wxBORDER_MASK;
+    style |= wxBORDER_NONE;
+    style |= wxWANTS_CHARS;
+    
     if(!wxControl::Create(parent, id, pos, size, style))
         return false;
     
@@ -187,6 +192,11 @@ wxAuiTabArt* wxAuiNotebook::GetArtProvider() const
 
 void wxAuiNotebook::SetWindowStyleFlag(long style)
 {
+    //Necessary for backwards compatibility with old wxAuiNotebook control - if we don't strip these flags then we end up with an ugly border around notebooks (where there was none before) in old code.
+    style &= ~wxBORDER_MASK;
+    style |= wxBORDER_NONE;
+    style |= wxWANTS_CHARS;
+    
     wxControl::SetWindowStyleFlag(style);
     
     // copy notebook dedicated style flags to the onboard manager flags

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -4593,6 +4593,11 @@ void wxAuiManager::DrawHintRect(wxWindow* paneWindow, const wxPoint& pt, const w
         {
             wxPoint screenPt = ::wxGetMousePosition();
             wxWindow* targetCtrl = ::wxFindWindowAtPoint(screenPt);
+	    
+	    // Make sure we have a target ctrl (it can be NULL if e.g. drop is outside of program window) - if we don't have one we don't draw a hint here.
+	    if(!targetCtrl)
+		return;
+	    
             // If we are on top of a hint window then quickly hide the hint window and get the window that is underneath it.
             if(targetCtrl==m_hintWnd)
             {
@@ -5808,73 +5813,78 @@ void wxAuiManager::OnLeftUp(wxMouseEvent& evt)
         wxPoint clientPt = m_frame->ScreenToClient(screenPt);
 
         wxWindow* targetCtrl = ::wxFindWindowAtPoint(screenPt);
-        // If we are on top of a hint window then quickly hide the hint window and get the window that is underneath it.
-        if(targetCtrl==m_hintWnd)
-        {
-            m_hintWnd->Hide();
-            targetCtrl = ::wxFindWindowAtPoint(screenPt);
-            m_hintWnd->Show();
-        }
-        // Find the manager this window belongs to (if it does belong to one)
-        wxAuiManager* otherMgr = NULL;
-        while(targetCtrl)
-        {
-            if(!wxDynamicCast(targetCtrl,wxAuiFloatingFrame))
-            {
-                if(targetCtrl->GetEventHandler() && wxDynamicCast(targetCtrl->GetEventHandler(),wxAuiManager))
-                {
-                    otherMgr = ((wxAuiManager*)targetCtrl->GetEventHandler());
-                    break;
-                }
-            }
-            targetCtrl = targetCtrl->GetParent();
-        }
+	
+	// Make sure we have a target ctrl (it can be NULL if e.g. drop is outside of program window)
+	if(targetCtrl)
+	{   
+		// If we are on top of a hint window then quickly hide the hint window and get the window that is underneath it.
+		if(targetCtrl==m_hintWnd)
+		{
+		m_hintWnd->Hide();
+		targetCtrl = ::wxFindWindowAtPoint(screenPt);
+		m_hintWnd->Show();
+		}
+		// Find the manager this window belongs to (if it does belong to one)
+		wxAuiManager* otherMgr = NULL;
+		while(targetCtrl)
+		{
+		if(!wxDynamicCast(targetCtrl,wxAuiFloatingFrame))
+		{
+			if(targetCtrl->GetEventHandler() && wxDynamicCast(targetCtrl->GetEventHandler(),wxAuiManager))
+			{
+			otherMgr = ((wxAuiManager*)targetCtrl->GetEventHandler());
+			break;
+			}
+		}
+		targetCtrl = targetCtrl->GetParent();
+		}
 
-        bool didDrop=false;
+		bool didDrop=false;
 
-        //Store paneWindow now as the below code block can invalidate pane
-        wxWindow* paneWindow=pane.GetWindow();
+		//Store paneWindow now as the below code block can invalidate pane
+		wxWindow* paneWindow=pane.GetWindow();
 
-        // Alert other manager of the drop and have it show hint.
-        if(otherMgr)
-        {
-            if(otherMgr != this)
-            {
-                didDrop = DoDropExternal(otherMgr, targetCtrl, pane, screenPt, wxPoint(0,0));
+		// Alert other manager of the drop and have it show hint.
+		if(otherMgr)
+		{
+		if(otherMgr != this)
+		{
+			didDrop = DoDropExternal(otherMgr, targetCtrl, pane, screenPt, wxPoint(0,0));
 
-                //Update ourselves here, the next block of code will update the target control
-                if(didDrop)
-                {
-                    Update();
-                    DoFrameLayout();
-                    Repaint();
-                }
-            }
-            else
-            {
-                didDrop = DoDrop(m_docks, m_panes, pane, clientPt, wxPoint(0,0));
-            }
-        }
+			//Update ourselves here, the next block of code will update the target control
+			if(didDrop)
+			{
+			Update();
+			DoFrameLayout();
+			Repaint();
+			}
+		}
+		else
+		{
+			didDrop = DoDrop(m_docks, m_panes, pane, clientPt, wxPoint(0,0));
+		}
+		}
 
-        //Warning! pane can be invalidated by the Update in above code block, so should not be used from this point onwards.
-        if(didDrop)
-        {
-            // Try reduce flicker, Update() calls Repaint() and then we set the active pane and Repaint() again, so use Freeze()/Thaw() to try avoid the double Repaint()
-            otherMgr->GetManagedWindow()->Freeze();
+		//Warning! pane can be invalidated by the Update in above code block, so should not be used from this point onwards.
+		if(didDrop)
+		{
+		// Try reduce flicker, Update() calls Repaint() and then we set the active pane and Repaint() again, so use Freeze()/Thaw() to try avoid the double Repaint()
+		otherMgr->GetManagedWindow()->Freeze();
 
-            // Update the layout to realize new position and e.g. form notebooks if needed.
-            otherMgr->Update();
+		// Update the layout to realize new position and e.g. form notebooks if needed.
+		otherMgr->Update();
 
-            // If a notebook formed we may have lost our active status so set it again.
-            otherMgr->SetActivePane(paneWindow);
+		// If a notebook formed we may have lost our active status so set it again.
+		otherMgr->SetActivePane(paneWindow);
 
-            // Allow the updated layout an opportunity to recalculate/update the pane positions.
-            otherMgr->DoFrameLayout();
+		// Allow the updated layout an opportunity to recalculate/update the pane positions.
+		otherMgr->DoFrameLayout();
 
-            // Make changes visible to user.
-            otherMgr->Repaint();
-            otherMgr->GetManagedWindow()->Thaw();
-        }
+		// Make changes visible to user.
+		otherMgr->Repaint();
+		otherMgr->GetManagedWindow()->Thaw();
+		}
+	}
 
 
 

--- a/src/aui/tabartgtk.cpp
+++ b/src/aui/tabartgtk.cpp
@@ -287,7 +287,7 @@ void wxAuiGtkTabArt::DrawTab(wxDC& dc, wxWindow* wnd, const wxAuiPaneInfo& page,
                          NULL);
 
     // figure out the size of the tab
-    wxSize tabSize = GetTabSize(dc, wnd, page.caption, page.GetBitmap(),
+    wxSize tabSize = GetTabSize(dc, wnd, page.caption, page.GetIcon(),
                                     page.HasFlag(wxAuiPaneInfo::optionActiveNotebook), closeButtonState, xExtent);
 
     wxRect tabRect = inRect;
@@ -426,12 +426,12 @@ void wxAuiGtkTabArt::DrawTab(wxDC& dc, wxWindow* wnd, const wxAuiPaneInfo& page,
     wxCoord textX = tabRect.x + padding + styleNotebook->xthickness;
 
     int bitmapX = 0;
-    if (page.GetBitmap().IsOk())
+    if (page.GetIcon().IsOk())
     {
         bitmapX = textX;
 
         // draw bitmap
-        int bitmapY = tabRect.y +(tabRect.height - page.GetBitmap().GetHeight()) / 2;
+        int bitmapY = tabRect.y +(tabRect.height - page.GetIcon().GetHeight()) / 2;
         if(!page.HasFlag(wxAuiPaneInfo::optionActiveNotebook))
         {
             if (HasFlag(wxAUI_NB_TOP))
@@ -439,12 +439,12 @@ void wxAuiGtkTabArt::DrawTab(wxDC& dc, wxWindow* wnd, const wxAuiPaneInfo& page,
             else
                 bitmapY -= styleNotebook->ythickness / 2;
         }
-        dc.DrawBitmap(page.GetBitmap(),
+        dc.DrawBitmap(page.GetIcon(),
                       bitmapX,
                       bitmapY,
                       true);
 
-        textX += page.GetBitmap().GetWidth() + padding;
+        textX += page.GetIcon().GetWidth() + padding;
     }
 
     wxCoord textW, textH, textY;


### PR DESCRIPTION
There is a crash (due to NULL dereference) if dragging out of a notebook and dropping outside the application window. This modifies the code to fix the crash.
