### PR TITLE
Fix incorrect virtual overload of GetBestTabCtrlSize

### DIFF
--- a/include/wx/aui/tabart.h
+++ b/include/wx/aui/tabart.h
@@ -59,12 +59,12 @@ public:
     virtual void SetMeasuringFont(const wxFont& font) = 0;
     virtual void SetColour(const wxColour& colour) = 0;
     virtual void SetActiveColour(const wxColour& colour) = 0;
-	// this should actually set the requested size
-	virtual void SetTabCtrlHeight(int size) = 0;
-	// this should actually set the requested size
-	virtual void SetTabCtrlWidth(int size) = 0;
+    // this should actually set the requested size
+    virtual void SetTabCtrlHeight(int size) = 0;
+    // this should actually set the requested size
+    virtual void SetTabCtrlWidth(int size) = 0;
 
-	virtual void SetUniformBitmapSize(const wxSize& size) = 0;
+    virtual void SetUniformBitmapSize(const wxSize& size) = 0;
 
     virtual void DrawBorder(
                             wxDC& dc,
@@ -125,9 +125,9 @@ public:
                          wxWindow* wnd,
                          const wxAuiPaneInfoPtrArray& pages) = 0;
 
-	// this should return -1,-1 if there is no requested width \ height
-	virtual wxSize GetRequestedSize() const = 0;
-	virtual wxSize GetRequiredBitmapSize() const = 0;
+    // this should return -1,-1 if there is no requested width \ height
+    virtual wxSize GetRequestedSize() const = 0;
+    virtual wxSize GetRequiredBitmapSize() const = 0;
 
     int m_fixedTabSize;
     int m_tabCtrlHeight;
@@ -154,9 +154,9 @@ public:
     void SetMeasuringFont(const wxFont& font);
     void SetColour(const wxColour& colour);
     void SetActiveColour(const wxColour& colour);
-	void SetTabCtrlHeight(int size);
-	void SetTabCtrlWidth(int size);
-	void SetUniformBitmapSize(const wxSize& size);
+    void SetTabCtrlHeight(int size);
+    void SetTabCtrlWidth(int size);
+    void SetUniformBitmapSize(const wxSize& size);
 
     void DrawBorder(
                  wxDC& dc,
@@ -220,8 +220,8 @@ public:
                  }
 
 
-	wxSize GetRequiredBitmapSize() const;
-	wxSize GetRequestedSize() const;
+    wxSize GetRequiredBitmapSize() const;
+    wxSize GetRequestedSize() const;
 
     // Returns true if the tabart has the given flag bit set
     bool HasFlag(int flag) const    { return (m_flags & flag) != 0; }
@@ -229,8 +229,8 @@ public:
     bool IsHorizontal() const { return HasFlag(wxAUI_NB_TOP | wxAUI_NB_BOTTOM); }
 
 protected:
-	wxSize m_requiredBitmapSize;
-	wxSize m_requestedSize;
+    wxSize m_requiredBitmapSize;
+    wxSize m_requestedSize;
 
     wxFont m_normalFont;
     wxFont m_selectedFont;
@@ -274,9 +274,9 @@ public:
     void SetMeasuringFont(const wxFont& font);
     void SetColour(const wxColour& colour);
     void SetActiveColour(const wxColour& colour);
-	void SetTabCtrlHeight(int size);
-	void SetTabCtrlWidth(int size);
-	void SetUniformBitmapSize(const wxSize& size);
+    void SetTabCtrlHeight(int size);
+    void SetTabCtrlWidth(int size);
+    void SetUniformBitmapSize(const wxSize& size);
 
     void DrawBorder(
                  wxDC& dc,
@@ -339,8 +339,8 @@ public:
                      return GetBestTabSize(wnd, pages, m_requiredBitmapSize).GetHeight();
                  }
 
-	wxSize GetRequiredBitmapSize() const;
-	wxSize GetRequestedSize() const;
+    wxSize GetRequiredBitmapSize() const;
+    wxSize GetRequestedSize() const;
 
     // Returns true if the tabart has the given flag bit set
     bool HasFlag(int flag) const    { return (m_flags & flag) != 0; }
@@ -348,8 +348,8 @@ public:
     bool IsHorizontal() const { return HasFlag(wxAUI_NB_TOP | wxAUI_NB_BOTTOM); }
 
 protected:
-	wxSize m_requiredBitmapSize;
-	wxSize m_requestedSize;
+    wxSize m_requiredBitmapSize;
+    wxSize m_requestedSize;
     wxFont m_normalFont;
     wxFont m_selectedFont;
     wxFont m_measuringFont;

--- a/include/wx/aui/tabartgtk.h
+++ b/include/wx/aui/tabartgtk.h
@@ -49,9 +49,9 @@ public:
                          int* xExtent);
     void DrawButton(wxDC& dc, wxWindow* wnd, const wxRect& inRect, int bitmapID, int buttonState, int orientation, wxRect* outRect);
     wxSize GetBestTabSize(wxWindow* wnd, const wxAuiPaneInfoPtrArray& pages, const wxSize& requiredBmpSize);
-    int GetBestTabCtrlSize(wxWindow* wnd, const wxAuiPaneInfoPtrArray& pages, const wxSize& requiredBmpSize)
+    int GetBestTabCtrlSize(wxWindow* wnd, const wxAuiPaneInfoPtrArray& pages)
                          {
-                             return GetBestTabSize(wnd, pages, requiredBmpSize).GetHeight();
+                             return GetBestTabSize(wnd, pages, m_requiredBitmapSize).GetHeight();
                          }
     int GetBorderWidth(wxWindow* wnd);
     int GetAdditionalBorderSpace(wxWindow* wnd);

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -124,7 +124,7 @@ void wxAuiNotebook::SetArtProvider(wxAuiTabArt* art)
 // any previous call and returns to the default behaviour
 void wxAuiNotebook::SetTabCtrlHeight(int height)
 {
-	GetArtProvider()->SetTabCtrlHeight(height);
+    GetArtProvider()->SetTabCtrlHeight(height);
 }
 
 void wxAuiNotebook::SetTabCtrlWidth(int width)
@@ -158,7 +158,7 @@ bool wxAuiNotebook::UpdateTabCtrlSize()
         return false;
 
 
-	// Are we supposed to update from the 'size' or what?
+    // Are we supposed to update from the 'size' or what?
 
     return true;
 }
@@ -174,7 +174,7 @@ wxSize wxAuiNotebook::CalculateTabCtrlSize()
     }
     
     wxSize tab_size = m_mgr.GetTabArtProvider()->GetBestTabSize((wxWindow*)this, allPanes,
-		m_mgr.GetTabArtProvider()->GetRequiredBitmapSize());
+        m_mgr.GetTabArtProvider()->GetRequiredBitmapSize());
     // if a fixed tab ctrl height is specified,
     // just use that instead of calculating a
     // tab height

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -2401,28 +2401,28 @@ void wxAuiManager::LayoutAddNotebook(wxAuiTabArt* tabArt,wxAuiTabContainer* note
 // It sends a EVT_AUI_PANE_DOCK_OVER that may be Vetoed() / Allowed() to overide the default behaviour.
 bool wxAuiManager::CanDockOver(wxAuiPaneInfo const &pane, wxAuiPaneInfo const &covered_pane) 
 {
-bool can_dock_over = false;
+    bool can_dock_over = false;
 
-// Basically, we can create a tab if a pane exactly overlaps another one
-if ( pane.GetPosition() == covered_pane.GetPosition() ) {
+    // Basically, we can create a tab if a pane exactly overlaps another one
+    if ( pane.GetPosition() == covered_pane.GetPosition() )
+    {
+        wxAuiPaneInfo evt_pane(pane); // we use a copy of the pane to forbid accidentally modifying the underlying one from "user space"
+        wxAuiPaneInfo evt_covered_pane(covered_pane);
 
-    wxAuiPaneInfo evt_pane(pane); // we use a copy of the pane to forbid accidentally modifying the underlying one from "user space"
-    wxAuiPaneInfo evt_covered_pane(covered_pane);
+        wxAuiManagerEvent evt(wxEVT_AUI_PANE_DOCK_OVER);
+        evt.SetManager(this);
+        evt.SetPane(&evt_pane);
+        evt.SetTargetPane(&evt_covered_pane);
+        evt.SetCanVeto(true);
+        evt.Veto( !wxDynamicCast(pane.GetWindow()->GetParent(), wxAuiNotebook) ); // By default, we allow docking over in wxAuiNotebook and forbid them elsewhere 
 
-    wxAuiManagerEvent evt(wxEVT_AUI_PANE_DOCK_OVER);
-    evt.SetManager(this);
-    evt.SetPane(&evt_pane);
-    evt.SetTargetPane(&evt_covered_pane);
-    evt.SetCanVeto(true);        
-    evt.Veto( !wxDynamicCast(pane.GetWindow()->GetParent(), wxAuiNotebook) ); // By default, we allow docking over in wxAuiNotebook and forbid them elsewhere 
+        GetManagedWindow()->ProcessWindowEvent(evt);
 
-    GetManagedWindow()->ProcessWindowEvent(evt);
+        can_dock_over = evt.IsAllowed();              
 
-    can_dock_over = evt.IsAllowed();              
-
-}
-
-return can_dock_over;
+    }
+    
+    return can_dock_over;
 }
 
 // This method tells if a pane must be set into a notebook, even if it's alone
@@ -4593,11 +4593,11 @@ void wxAuiManager::DrawHintRect(wxWindow* paneWindow, const wxPoint& pt, const w
         {
             wxPoint screenPt = ::wxGetMousePosition();
             wxWindow* targetCtrl = ::wxFindWindowAtPoint(screenPt);
-	    
-	    // Make sure we have a target ctrl (it can be NULL if e.g. drop is outside of program window) - if we don't have one we don't draw a hint here.
-	    if(!targetCtrl)
-		return;
-	    
+    
+            // Make sure we have a target ctrl (it can be NULL if e.g. drop is outside of program window) - if we don't have one we don't draw a hint here.
+            if(!targetCtrl)
+                return;
+    
             // If we are on top of a hint window then quickly hide the hint window and get the window that is underneath it.
             if(targetCtrl==m_hintWnd)
             {
@@ -5716,7 +5716,7 @@ void wxAuiManager::OnLeftUp(wxMouseEvent& evt)
         
         if (m_actionPart)
         {
-			wxAuiPaneInfo& pane = *m_actionPart->pane;
+            wxAuiPaneInfo& pane = *m_actionPart->pane;
  
             bool passHitTest=false;
             int buttonid=0;
@@ -5813,78 +5813,78 @@ void wxAuiManager::OnLeftUp(wxMouseEvent& evt)
         wxPoint clientPt = m_frame->ScreenToClient(screenPt);
 
         wxWindow* targetCtrl = ::wxFindWindowAtPoint(screenPt);
-	
-	// Make sure we have a target ctrl (it can be NULL if e.g. drop is outside of program window)
-	if(targetCtrl)
-	{   
-		// If we are on top of a hint window then quickly hide the hint window and get the window that is underneath it.
-		if(targetCtrl==m_hintWnd)
-		{
-		m_hintWnd->Hide();
-		targetCtrl = ::wxFindWindowAtPoint(screenPt);
-		m_hintWnd->Show();
-		}
-		// Find the manager this window belongs to (if it does belong to one)
-		wxAuiManager* otherMgr = NULL;
-		while(targetCtrl)
-		{
-		if(!wxDynamicCast(targetCtrl,wxAuiFloatingFrame))
-		{
-			if(targetCtrl->GetEventHandler() && wxDynamicCast(targetCtrl->GetEventHandler(),wxAuiManager))
-			{
-			otherMgr = ((wxAuiManager*)targetCtrl->GetEventHandler());
-			break;
-			}
-		}
-		targetCtrl = targetCtrl->GetParent();
-		}
 
-		bool didDrop=false;
+        // Make sure we have a target ctrl (it can be NULL if e.g. drop is outside of program window)
+        if(targetCtrl)
+        {   
+                // If we are on top of a hint window then quickly hide the hint window and get the window that is underneath it.
+                if(targetCtrl==m_hintWnd)
+                {
+                    m_hintWnd->Hide();
+                    targetCtrl = ::wxFindWindowAtPoint(screenPt);
+                    m_hintWnd->Show();
+                }
+                // Find the manager this window belongs to (if it does belong to one)
+                wxAuiManager* otherMgr = NULL;
+                while(targetCtrl)
+                {
+                    if(!wxDynamicCast(targetCtrl,wxAuiFloatingFrame))
+                    {
+                        if(targetCtrl->GetEventHandler() && wxDynamicCast(targetCtrl->GetEventHandler(),wxAuiManager))
+                        {
+                            otherMgr = ((wxAuiManager*)targetCtrl->GetEventHandler());
+                            break;
+                        }
+                    }
+                    targetCtrl = targetCtrl->GetParent();
+                }
 
-		//Store paneWindow now as the below code block can invalidate pane
-		wxWindow* paneWindow=pane.GetWindow();
+                bool didDrop=false;
 
-		// Alert other manager of the drop and have it show hint.
-		if(otherMgr)
-		{
-		if(otherMgr != this)
-		{
-			didDrop = DoDropExternal(otherMgr, targetCtrl, pane, screenPt, wxPoint(0,0));
+                //Store paneWindow now as the below code block can invalidate pane
+                wxWindow* paneWindow=pane.GetWindow();
 
-			//Update ourselves here, the next block of code will update the target control
-			if(didDrop)
-			{
-			Update();
-			DoFrameLayout();
-			Repaint();
-			}
-		}
-		else
-		{
-			didDrop = DoDrop(m_docks, m_panes, pane, clientPt, wxPoint(0,0));
-		}
-		}
+                // Alert other manager of the drop and have it show hint.
+                if(otherMgr)
+                {
+                    if(otherMgr != this)
+                    {
+                        didDrop = DoDropExternal(otherMgr, targetCtrl, pane, screenPt, wxPoint(0,0));
 
-		//Warning! pane can be invalidated by the Update in above code block, so should not be used from this point onwards.
-		if(didDrop)
-		{
-		// Try reduce flicker, Update() calls Repaint() and then we set the active pane and Repaint() again, so use Freeze()/Thaw() to try avoid the double Repaint()
-		otherMgr->GetManagedWindow()->Freeze();
+                        //Update ourselves here, the next block of code will update the target control
+                        if(didDrop)
+                        {
+                            Update();
+                            DoFrameLayout();
+                            Repaint();
+                        }
+                    }
+                    else
+                    {
+                        didDrop = DoDrop(m_docks, m_panes, pane, clientPt, wxPoint(0,0));
+                    }
+                }
 
-		// Update the layout to realize new position and e.g. form notebooks if needed.
-		otherMgr->Update();
+                //Warning! pane can be invalidated by the Update in above code block, so should not be used from this point onwards.
+                if(didDrop)
+                {
+                    // Try reduce flicker, Update() calls Repaint() and then we set the active pane and Repaint() again, so use Freeze()/Thaw() to try avoid the double Repaint()
+                    otherMgr->GetManagedWindow()->Freeze();
 
-		// If a notebook formed we may have lost our active status so set it again.
-		otherMgr->SetActivePane(paneWindow);
+                    // Update the layout to realize new position and e.g. form notebooks if needed.
+                    otherMgr->Update();
 
-		// Allow the updated layout an opportunity to recalculate/update the pane positions.
-		otherMgr->DoFrameLayout();
+                    // If a notebook formed we may have lost our active status so set it again.
+                    otherMgr->SetActivePane(paneWindow);
 
-		// Make changes visible to user.
-		otherMgr->Repaint();
-		otherMgr->GetManagedWindow()->Thaw();
-		}
-	}
+                    // Allow the updated layout an opportunity to recalculate/update the pane positions.
+                    otherMgr->DoFrameLayout();
+
+                    // Make changes visible to user.
+                    otherMgr->Repaint();
+                    otherMgr->GetManagedWindow()->Thaw();
+                }
+        }
 
 
 

--- a/src/aui/tabart.cpp
+++ b/src/aui/tabart.cpp
@@ -161,8 +161,8 @@ static const unsigned char list_bits[] = {
 
 wxAuiGenericTabArt::wxAuiGenericTabArt()
 {
-	m_requestedSize.x = -1;
-	m_requestedSize.y = -1;
+    m_requestedSize.x = -1;
+    m_requestedSize.y = -1;
     m_normalFont = *wxNORMAL_FONT;
     m_selectedFont = *wxNORMAL_FONT;
     m_selectedFont.SetWeight(wxFONTWEIGHT_BOLD);
@@ -294,22 +294,22 @@ void wxAuiGenericTabArt::SetSizingInfo(const wxSize& tabCtrlSize, size_t tabCoun
 
 void wxAuiGenericTabArt::SetTabCtrlHeight(int size)
 {
-	m_requestedSize.y = size;
+    m_requestedSize.y = size;
 }
 
 void wxAuiGenericTabArt::SetTabCtrlWidth(int size)
 {
-	m_requestedSize.x = size;
+    m_requestedSize.x = size;
 }
 
 void wxAuiGenericTabArt::SetUniformBitmapSize(const wxSize& size)
 {
-	m_requiredBitmapSize = size;
+    m_requiredBitmapSize = size;
 }
 
 wxSize wxAuiGenericTabArt::GetRequestedSize() const
 {
-	return wxSize(m_tabCtrlWidth, m_tabCtrlHeight);
+    return wxSize(m_tabCtrlWidth, m_tabCtrlHeight);
 }
 
 void wxAuiGenericTabArt::DrawBorder(wxDC& dc, wxWindow* wnd, const wxRect& rect)
@@ -1094,7 +1094,7 @@ void wxAuiGenericTabArt::SetActiveColour(const wxColour& colour)
 
 wxSize wxAuiGenericTabArt::GetRequiredBitmapSize() const
 {
-	return m_requiredBitmapSize;
+    return m_requiredBitmapSize;
 }
 
 // -- wxAuiSimpleTabArt class implementation --
@@ -1105,8 +1105,8 @@ wxAuiSimpleTabArt::wxAuiSimpleTabArt()
     m_selectedFont = *wxNORMAL_FONT;
     m_selectedFont.SetWeight(wxFONTWEIGHT_BOLD);
     m_measuringFont = m_selectedFont;
-	m_requestedSize.x = -1;
-	m_requestedSize.y = -1;
+    m_requestedSize.x = -1;
+    m_requestedSize.y = -1;
     m_flags = 0;
     m_fixedTabSize = 20;
 
@@ -1719,27 +1719,27 @@ void wxAuiSimpleTabArt::SetMeasuringFont(const wxFont& font)
 
 void wxAuiSimpleTabArt::SetTabCtrlHeight(int size)
 {
-	m_requestedSize.y = size;
+    m_requestedSize.y = size;
 }
 
 void wxAuiSimpleTabArt::SetTabCtrlWidth(int size)
 {
-	m_requestedSize.x = size;
+    m_requestedSize.x = size;
 }
 
 void wxAuiSimpleTabArt::SetUniformBitmapSize(const wxSize& size)
 {
-	m_requiredBitmapSize = size;
+    m_requiredBitmapSize = size;
 }
 
 wxSize wxAuiSimpleTabArt::GetRequestedSize() const
 {
-	return wxSize(m_tabCtrlWidth, m_tabCtrlHeight);
+    return wxSize(m_tabCtrlWidth, m_tabCtrlHeight);
 }
 
 wxSize wxAuiSimpleTabArt::GetRequiredBitmapSize() const
 {
-	return m_requiredBitmapSize;
+    return m_requiredBitmapSize;
 }
 
 #endif // wxUSE_AUI


### PR DESCRIPTION
It seems all the ones in tabart.h got updated at some point but tabartgtk.h was missed.
Some tab->space whitespace correction(s) - it seems a lot of the recent changes have been done using tabs but the erst of the code uses spaces.
