### PR TITLE
Avoid crash when moving 'static' auinotebook tab to 'dynamic' pane

### DIFF
--- a/src/aui/dockart.cpp
+++ b/src/aui/dockart.cpp
@@ -784,9 +784,11 @@ wxAuiTabContainer::wxAuiTabContainer(wxAuiTabArt* artProvider,wxAuiManager* mgr)
 wxAuiTabContainer::~wxAuiTabContainer()
 {
     unsigned int i;
-    for(i=0;i<m_pages.GetCount();i++)
+    for(i = 0; i < m_pages.GetCount(); ++i)
     {
-        m_pages[i]->GetWindow()->Disconnect( wxEVT_KEY_DOWN, wxKeyEventHandler(wxAuiTabContainer::OnChildKeyDown) );
+        wxWindow *window = m_pages[i]->GetWindow();
+        if (window)
+            window->Disconnect( wxEVT_KEY_DOWN, wxKeyEventHandler(wxAuiTabContainer::OnChildKeyDown) );
     }
 }
 
@@ -914,14 +916,18 @@ bool wxAuiTabContainer::AddPage(wxAuiPaneInfo& info)
 
 bool wxAuiTabContainer::InsertPage(wxWindow* page, wxAuiPaneInfo& info, size_t idx)
 {
-    info.GetWindow()->Connect( wxEVT_KEY_DOWN, wxKeyEventHandler(wxAuiTabContainer::OnChildKeyDown)  ,NULL,this);
+    if (info.GetWindow())
+        info.GetWindow()->Connect( wxEVT_KEY_DOWN, wxKeyEventHandler(wxAuiTabContainer::OnChildKeyDown)  ,NULL,this);
 
     info.Window(page);
 
-    if (idx >= m_pages.GetCount()) {
+    if (idx >= m_pages.GetCount())
+    {
         info.Page(m_pages.size());
         m_pages.Add(&info);        
-    } else {
+    }
+    else
+    {
         m_pages.Insert(&info, idx);
         for(size_t i=idx; i < m_pages.GetCount(); i++)
             m_pages[i]->Page(i);
@@ -960,7 +966,7 @@ bool wxAuiTabContainer::RemovePage(wxWindow* wnd)
     for (i = 0; i < pageCount; ++i)
     {
         wxAuiPaneInfo& page = *m_pages.Item(i);
-        if (page.GetWindow() == wnd)
+        if (wnd && page.GetWindow() == wnd)
         {
             m_pages.RemoveAt(i);
 
@@ -986,6 +992,9 @@ bool wxAuiTabContainer::SetActivePage(wxWindow* wnd)
     for (i = 0; i < pageCount; ++i)
     {
         wxAuiPaneInfo& page = *m_pages.Item(i);
+        if (!page.GetWindow())
+            continue;
+
         if (page.GetWindow() == wnd)
         {
             if (page.HasFlag(wxAuiPaneInfo::optionActiveNotebook) && page.GetWindow()->IsShown())
@@ -1804,7 +1813,7 @@ void wxAuiTabContainer::MakeTabVisible(int tabPage)
     }
 }
 
-void wxAuiTabContainer::MakeTabVisible(int tabPage, wxWindow* win)
+void wxAuiTabContainer::MakeTabVisible(int tabPage, wxWindow* WXUNUSED(win))
 {
 	MakeTabVisible(tabPage);
 }

--- a/src/aui/floatpane.cpp
+++ b/src/aui/floatpane.cpp
@@ -53,6 +53,7 @@ wxAuiFloatingFrame::wxAuiFloatingFrame(wxWindow* parent,
                         (pane.HasMaximizeButton()?wxMAXIMIZE_BOX:0) |
                         (pane.IsFixed()?0:wxRESIZE_BORDER)
                         )
+                , m_paneWindow(NULL)
 {
     m_ownerMgr = owner_mgr;
     m_moving = false;
@@ -83,6 +84,9 @@ wxAuiFloatingFrame::~wxAuiFloatingFrame()
 
 void wxAuiFloatingFrame::SetPaneWindow(const wxAuiPaneInfo& pane)
 {
+    if (!pane.GetWindow())
+        return;
+
     m_paneWindow = pane.GetWindow();
     m_paneWindow->Reparent(this);
 

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -2714,8 +2714,10 @@ void wxAuiManager::LayoutAddDock(wxSizer* cont, wxAuiDockInfo& dock, wxAuiDockUI
                             ShowWnd(pane.GetWindow(),true);
                         activenotebookpagefound = true;
                     }
-                    //else
-                        // Add a debug warning
+                    else
+                    {
+                        wxFAIL_MSG("Flag optionActiveNotebook should not be defined to several wxAuiPaneInfo");
+                    }
                 }
                 else
                 {

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -92,6 +92,9 @@ IMPLEMENT_CLASS(wxAuiManager, wxEvtHandler)
 // as the Show() method on this class is "unplugged"
 static void ShowWnd(wxWindow* wnd, bool show)
 {
+    if (!wnd)
+        return;
+
 #if wxUSE_MDI
     if (wxDynamicCast(wnd,wxAuiMDIChildFrame))
     {
@@ -1041,6 +1044,9 @@ bool wxAuiManager_HasLiveResize(wxAuiManager& manager)
 // need to be managed by the manager itself.
 wxAuiManager* wxAuiManager::GetManager(wxWindow* window)
 {
+    if (!window)
+        return NULL;
+
     wxAuiManagerEvent evt(wxEVT_AUI_FIND_MANAGER);
     evt.SetManager(NULL);
     evt.SetEventObject(window);
@@ -2397,6 +2403,7 @@ void wxAuiManager::LayoutAddDock(wxSizer* cont, wxAuiDockInfo& dock, wxAuiDockUI
 {
     wxSizerItem* sizerItem;
     wxAuiDockUIPart part;
+    part.pane = NULL;
 
     int sashSize = m_art->GetMetric(wxAUI_DOCKART_SASH_SIZE);
     int orientation = dock.IsHorizontal() ? wxHORIZONTAL : wxVERTICAL;
@@ -2715,7 +2722,7 @@ void wxAuiManager::LayoutAddDock(wxSizer* cont, wxAuiDockInfo& dock, wxAuiDockUI
                     // Only hide the window if it belongs to us.
                     // It might not belong to us if we are in the middle of a drop calculation for
                     // a floating frame, hiding it in this case would make the floating frame blank.
-                    if(pane.GetWindow()->GetParent()==m_frame)
+                    if(pane.GetWindow() && pane.GetWindow()->GetParent()==m_frame)
                     {
                         // Don't ever hide or show a window during hint calculation as this can affect display of windows other than the hint one.
                         if(!m_doingHintCalculation)
@@ -2825,7 +2832,7 @@ void wxAuiManager::LayoutAddDock(wxSizer* cont, wxAuiDockInfo& dock, wxAuiDockUI
                         // Only hide the window if it belongs to us.
                         // It might not belong to us if we are in the middle of a drop calculation for
                         // a floating frame, hiding it in this case would make the floating frame blank.
-                        if(pane.GetWindow()->GetParent()==m_frame)
+                        if(pane.GetWindow() && pane.GetWindow()->GetParent()==m_frame)
                         {
                             // Don't ever hide or show a window during hint calculation as this can affect display of windows other than the hint one.
                             if(!m_doingHintCalculation)
@@ -3380,7 +3387,7 @@ void wxAuiManager::Update()
     {
         wxAuiPaneInfo& p = m_panes.Item(i);
 
-        if (!p.IsFloating() && p.GetFrame())
+        if (!p.IsFloating() && p.GetFrame() && p.GetWindow())
         {
             // because the pane is no longer in a floating, we need to
             // reparent it to m_frame and destroy the floating frame
@@ -3484,7 +3491,7 @@ void wxAuiManager::Update()
         }
         else
         {
-            if (p.GetWindow()->IsShown() != p.IsShown())
+            if (p.GetWindow() && p.GetWindow()->IsShown() != p.IsShown())
             {
                 // Hide windows we are sure are hidden
                 // Other panes will be processed later
@@ -4713,7 +4720,7 @@ void wxAuiManager::OnFloatingPaneMoving(wxWindow* wnd, wxDirection dir)
 
     // calculate the offset from the upper left-hand corner
     // of the frame to the mouse pointer
-    wxPoint framePos = pane.GetFrame()->GetPosition();
+    wxPoint framePos = pane.GetFrame() ? pane.GetFrame()->GetPosition() : wxPoint(0,0);
     wxPoint actionOffset(pt.x-framePos.x, pt.y-framePos.y);
 
     // no hint for toolbar floating windows
@@ -4813,7 +4820,7 @@ void wxAuiManager::OnFloatingPaneMoved(wxWindow* wnd, wxDirection dir)
 
     // calculate the offset from the upper left-hand corner
     // of the frame to the mouse pointer
-    wxPoint framePos = pane.GetFrame()->GetPosition();
+    wxPoint framePos = pane.GetFrame() ? pane.GetFrame()->GetPosition() : wxPoint(0,0);
     wxPoint actionOffset(pt.x-framePos.x, pt.y-framePos.y);
 
     // if a key modifier is pressed while dragging the frame,


### PR DESCRIPTION
Check some pointers before use to avoid crashes when flags are not correctly set.

Perhaps an assert should be defined somewhere to check that if the flag wxAUI_NB_TAB_EXTERNAL_MOVE is set on the 'source' notebook, the flag wxAUI_MGR_ALLOW_EXTERNAL_MOVE is also set on the 'destination' manager?.

(P.S. This pull request is a clone of https://github.com/nhold/wxWidgets/pull/78 but with a better history...)
