### PR TITLE
Avoids to reset the pane's state when defining the CenterPane capability

### DIFF
--- a/include/wx/aui/framemanager.h
+++ b/include/wx/aui/framemanager.h
@@ -442,7 +442,6 @@ public:
     wxAuiPaneInfo& CentrePane() { return CenterPane(); }
     wxAuiPaneInfo& CenterPane()
     {
-        state = 0;
         return Center().PaneBorder().Resizable();
     }
 


### PR DESCRIPTION
Related to the issue revealed by _fastworks_ in https://github.com/nhold/wxWidgets/issues/24.

I think it's not relevant anymore to reset the pane's state since we can use the center area as a docking position as another.
