### PR TITLE
Corrected the construction order of the tabs of the tabs container

### DIFF
--- a/include/wx/aui/framemanager.h
+++ b/include/wx/aui/framemanager.h
@@ -573,7 +573,7 @@ public:
 private:
 
     wxString m_tooltip;     // tooltip displayed when hovering over title/tab of window
-    int      m_dock_page;   // tab position if we are in a notebook (0 = leftmost tab)
+    int      m_dock_page;   // tab position if we are in a notebook (0 = leftmost tab, -1 rightmost tab)
 
 
 };

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -137,7 +137,7 @@ wxAuiPaneInfo::wxAuiPaneInfo()
   floating_size(wxDefaultSize),
   dock_proportion(0),
   m_tooltip(wxT("")),
-  m_dock_page(0)
+  m_dock_page(wxNOT_FOUND)
 {
     DefaultPane();
 }

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -1294,6 +1294,27 @@ bool wxAuiManager::AddPane(wxWindow* window, const wxAuiPaneInfo& paneInfo)
         }
     }
 
+    // Avoids duplicates in page numbers
+    wxAuiPaneInfo *t = &test;
+    bool increment = false;
+    for (size_t i = 0; i < m_panes.GetCount(); ++i)
+    {
+        wxAuiPaneInfo &item = m_panes.Item(i);
+        wxAuiPaneInfo *p = &item;
+        if (PaneSortFunc(&p, &t) == 1)
+        {
+            if (!increment && (p->GetPage() == t->GetPage()))
+            {
+                p->Page(p->GetPage()+1);
+                increment = true;
+            }
+            else if (increment)
+            {
+                p->Page(p->GetPage()+1);
+            }
+        }
+    }
+
     m_panes.Add(test);
 
     wxAuiPaneInfo& pinfo = m_panes.Last();


### PR DESCRIPTION
Related to the issue https://github.com/nhold/wxWidgets/issues/83

This patch:
- sets the default value for `m_dock_page` to `wxNOT_FOUND` (-1) to differentiate a page number defined by the user than a default behavior.
- checks for duplicates in the page numbers before insertion of the pane
