### PR TITLE
Fix a regression in persepctive saving/loading for panes with empty names

### DIFF
--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -1332,7 +1332,7 @@ bool wxAuiManager::AddPane(wxWindow* window, const wxAuiPaneInfo& paneInfo)
     // if the pane's name identifier is blank, create a random string
     if (pinfo.GetName().empty() || alreadyExists)
     {
-        pinfo.GetName().Printf(wxT("%08lx%08x%08x%08lx"),
+        pinfo.Name(wxString::Format(wxT("%08lx%08x%08x%08lx"),
              (unsigned long)wxPtrToUInt(pinfo.GetWindow()) & 0xffffffff,
              (unsigned int)time(NULL),
 #ifdef __WXWINCE__
@@ -1340,7 +1340,8 @@ bool wxAuiManager::AddPane(wxWindow* window, const wxAuiPaneInfo& paneInfo)
 #else
              (unsigned int)clock(),
 #endif
-             (unsigned long)m_panes.GetCount());
+             (unsigned long)m_panes.GetCount()));
+        
     }
 
     // set initial proportion (if not already set)


### PR DESCRIPTION
Panes with empty names are meant to have a 'random' name assigned when the paneinfo is added to the frame manager, due to a regression in the code this wasn't happening, which in turn causes issues when saving/loading the perspective.
Issue was only visible if two or more panes with names were present.

Fixes #104
