### PR TITLE
Fix a backwards compatibility issue with wxAuiManager.

### DIFF
--- a/include/wx/aui/framemanager.h
+++ b/include/wx/aui/framemanager.h
@@ -455,12 +455,12 @@ public:
        test.state |= optionTopDockable | optionBottomDockable |
                  optionLeftDockable | optionRightDockable |
                  optionFloatable | optionMovable | optionResizable |
-                 optionCaption | optionPaneBorder | buttonClose | optionDestroyOnClose;
+                 optionCaption | optionPaneBorder | buttonClose;
         wxCHECK_MSG(test.IsValid(), *this, "window settings and pane settings are incompatible");
         this->state |= optionTopDockable | optionBottomDockable |
                  optionLeftDockable | optionRightDockable |
                  optionFloatable | optionMovable | optionResizable |
-				 optionCaption | optionPaneBorder | buttonClose | optionDestroyOnClose;
+				 optionCaption | optionPaneBorder | buttonClose;
         return *this;
     }
 

--- a/interface/wx/aui/auibook.h
+++ b/interface/wx/aui/auibook.h
@@ -24,7 +24,12 @@
     wxAuiNotebook::SetArtProvider(). By default, native art provider is used if
     available (currently only in wxGTK) and wxAuiGenericTabArt otherwise.
     
-    Since version 3.1, this is mostly a wrapper around the standard notebook management features built in the wxAuiManager class.
+    Since version 3.1, this is mostly implemented as a wrapper around the standard notebook
+    management features built in the wxAuiManager class.
+
+    Note: The default behaviour of wxAuiNotebook is to destroy pages when they
+    are closed and not hide them, this is contradictory to the behaviour of wxAuiManager
+    which by default destroys pages on close.
 
     @beginStyleTable
     @style{wxAUI_NB_DEFAULT_STYLE}

--- a/interface/wx/aui/framemanager.h
+++ b/interface/wx/aui/framemanager.h
@@ -150,8 +150,13 @@ enum wxAuiManagerOption
     m_mgr.GetPane(text1).Float();
     @endcode
 
+    Note: The default behaviour of wxAuiManager is to hide panes when they
+    are closed and not destroy them, as this allows the loading and saving of
+    perspectives to function. This is contradictory to the behaviour of wxAuiNotebook
+    which by default destroys pages on close.   
 
-    @section auimanager_layers Layers, Rows and Directions, Positions
+
+    @section auimanager_layers Layers, Rows and Directions, Positions, Pages
 
     Inside wxAUI, the docking layout is figured out by checking several pane
     parameters. Five of these are important for determining where a pane will
@@ -183,6 +188,8 @@ enum wxAuiManagerOption
         Tab position will be decided based on the Page values of the panes with
         those that have a lower value appearing on the left, with 0 being the
         absolute left. By default, pages are not enabled.
+        This behaviour can be controlled using the wxAUI_MGR_NB_ALLOW_NOTEBOOKS flag as well as EVT_AUI_PANE_DOCK_OVER
+
 
     @beginStyleTable
     @style{wxAUI_MGR_ALLOW_FLOATING}

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -229,7 +229,7 @@ bool wxAuiNotebook::InsertPage(size_t pageIndex, wxWindow* page, const wxString&
     // Shift other panes so that this one can go in between them if necessary
     wxAuiDoInsertPage(m_mgr.GetAllPanes(),1,0,1,0,pageIndex);
     
-    m_mgr.AddPane(page, wxAuiPaneInfo().Centre().Layer(0).Position(0).Caption(caption).Floatable(false).Movable().Page(pageIndex).Icon(bitmap).Dockable(m_mgr.HasFlag(wxAUI_NB_TAB_SPLIT)).CloseButton(false).AlwaysDockInNotebook());
+    m_mgr.AddPane(page, wxAuiPaneInfo().Centre().Layer(0).Position(0).Caption(caption).Floatable(false).Movable().Page(pageIndex).Icon(bitmap).Dockable(m_mgr.HasFlag(wxAUI_NB_TAB_SPLIT)).CloseButton(false).AlwaysDockInNotebook().DestroyOnClose());
 
     // Change the selection if explicitly requested, or if the page is the first one; for the later case, it ensures that there is a current page in the notebook.
     if (select || GetPageCount() == 1)


### PR DESCRIPTION
Remove the optionDestroyOnClose flag from default flags.
Instead have wxAuiNotebook add this flag when it adds pages, this allows backwardsc ompatibility but may make the API confusing in some cases.
Document this for both wxAuiManager and wxAuiNotebook.

Closes #106
