### PR TITLE
Define wxAuiTabContainer as event object to the wxAuiNotebookEvent objects

### DIFF
--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -280,6 +280,7 @@ wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_AUI, wxEVT_AUINOTEBOOK_TAB_RIGHT_DOWN, wxAu
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_AUI, wxEVT_AUINOTEBOOK_TAB_RIGHT_UP, wxAuiNotebookEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_AUI, wxEVT_AUINOTEBOOK_DRAG_DONE, wxAuiNotebookEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_AUI, wxEVT_AUINOTEBOOK_BG_DCLICK, wxAuiNotebookEvent);
+wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_AUI, wxEVT_AUINOTEBOOK_CANCEL_DRAG, wxAuiNotebookEvent);
 
 typedef void (wxEvtHandler::*wxAuiNotebookEventFunction)(wxAuiNotebookEvent&);
 
@@ -316,6 +317,8 @@ typedef void (wxEvtHandler::*wxAuiNotebookEventFunction)(wxAuiNotebookEvent&);
     wx__DECLARE_EVT1(wxEVT_AUINOTEBOOK_TAB_RIGHT_UP, winid, wxAuiNotebookEventHandler(fn))
 #define EVT_AUINOTEBOOK_BG_DCLICK(winid, fn) \
     wx__DECLARE_EVT1(wxEVT_AUINOTEBOOK_BG_DCLICK, winid, wxAuiNotebookEventHandler(fn))
+#define EVT_AUINOTEBOOK_CANCEL_DRAG(winid, fn) \
+    wx__DECLARE_EVT1(wxEVT_AUINOTEBOOK_CANCEL_DRAG, winid, wxAuiNotebookEventHandler(fn))
 #else
 
 // wxpython/swig event work
@@ -334,6 +337,7 @@ typedef void (wxEvtHandler::*wxAuiNotebookEventFunction)(wxAuiNotebookEvent&);
 %constant wxEventType wxEVT_AUINOTEBOOK_TAB_RIGHT_DOWN;
 %constant wxEventType wxEVT_AUINOTEBOOK_TAB_RIGHT_UP;
 %constant wxEventType wxEVT_AUINOTEBOOK_BG_DCLICK;
+%constant wxEventType wxEVT_AUINOTEBOOK_CANCEL_DRAG;
 
 %pythoncode {
     EVT_AUINOTEBOOK_PAGE_CLOSE = wx.PyEventBinder( wxEVT_AUINOTEBOOK_PAGE_CLOSE, 1 )
@@ -351,6 +355,7 @@ typedef void (wxEvtHandler::*wxAuiNotebookEventFunction)(wxAuiNotebookEvent&);
     EVT__AUINOTEBOOK_TAB_RIGHT_DOWN = wx.PyEventBinder( wxEVT_AUINOTEBOOK_TAB_RIGHT_DOWN, 1 )
     EVT__AUINOTEBOOK_TAB_RIGHT_UP = wx.PyEventBinder( wxEVT_AUINOTEBOOK_TAB_RIGHT_UP, 1 )
     EVT_AUINOTEBOOK_BG_DCLICK = wx.PyEventBinder( wxEVT_AUINOTEBOOK_BG_DCLICK, 1 )
+    EVT_AUINOTEBOOK_CANCEL_DRAG = wx.PyEventBinder( wxEVT_AUINOTEBOOK_CANCEL_DRAG, 1 )
 }
 #endif
 


### PR DESCRIPTION
Checked and modified the `wxAuiNotebookEvent` object's content sent by the frame manager to be consistent with the behavior of the 'old aui':
-  primarily set `wxAuiTabContainer` as event object when expected (most of the time excepted for some dnd events)
- set the page ID related to the tab container for 'selected page' and 'old selected page'
- added the missing `wxEVT_AUINOTEBOOK_CANCEL_DRAG` event (should ease catching the event anew in the wxAuiNotebook::OnTabCancelDrag - see issue https://github.com/nhold/wxWidgets/issues/108)

This patch should answer to the issue https://github.com/nhold/wxWidgets/issues/111
