### PR TITLE
Corrected reentry in wxAuiTabContainer::SetActivePage() due to SetFocus() operation 

### DIFF
--- a/src/aui/dockart.cpp
+++ b/src/aui/dockart.cpp
@@ -1008,9 +1008,10 @@ bool wxAuiTabContainer::SetActivePage(wxWindow* wnd)
             else
             {
                 page.GetWindow()->Show(true);
-                page.GetWindow()->SetFocus();
+                // set active flag before focus to avoid reentry from wxAuiManager::OnChildFocus()
                 page.SetFlag(wxAuiPaneInfo::optionActive,true);
                 page.SetFlag(wxAuiPaneInfo::optionActiveNotebook,true);
+                page.GetWindow()->SetFocus();
                 found = true;
                 MakeTabVisible(i);
             }


### PR DESCRIPTION
Corrects issue https://github.com/nhold/wxWidgets/issues/131
