### PR TITLE
Avoids to close the floating frame when the pane closure is vetoed

### DIFF
--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -4902,13 +4902,16 @@ void wxAuiManager::OnFloatingPaneResized(wxWindow* wnd, const wxRect& rect)
 }
 
 
-void wxAuiManager::OnFloatingPaneClosed(wxWindow* wnd, wxCloseEvent& WXUNUSED(evt))
+void wxAuiManager::OnFloatingPaneClosed(wxWindow* wnd, wxCloseEvent& evt)
 {
     // try to find the pane
     wxAuiPaneInfo& pane = GetPane(wnd);
     wxASSERT_MSG(pane.IsOk(), wxT("Pane window not found"));
 
-    ClosePane(pane);
+    if (!ClosePane(pane))
+    {
+        evt.Veto();
+    }
 }
 
 


### PR DESCRIPTION
Answers to the issue https://github.com/nhold/wxWidgets/issues/135

`wxAuiFloatingFrame::OnClose` calls `OnFloatingPaneClosed()` which calls `ClosePane()`.
If the user does not allow the closure, `ClosePane()` returns `false` but the Veto was not propagated.
